### PR TITLE
SC866 Execute Stream-Security hook before apache caching hook 

### DIFF
--- a/mod_stream_security.c
+++ b/mod_stream_security.c
@@ -145,7 +145,9 @@ static void register_hooks(apr_pool_t *pool) {
     config.keyPath = DEFAULT_KEY_PATH;
     config.strict = 1;
     /* Hook the request handler */
-    ap_hook_handler(stream_security_handler, NULL, NULL, APR_HOOK_LAST);
+
+    static const char * const hookToCallAfter[] = { "mod_cache.c", NULL };    
+    ap_hook_handler(stream_security_handler, NULL, hookToCallAfter, APR_HOOK_FIRST); 
 }
 
 void debug_print_data(request_rec *r, char* resource, struct ResourceRequest resourceRequest) {


### PR DESCRIPTION
To check access rights before a cached file is delivered